### PR TITLE
Load save

### DIFF
--- a/EZPrefine_PINT_MCMC.py
+++ b/EZPrefine_PINT_MCMC.py
@@ -239,7 +239,7 @@ class MCMC:
 
         # add the weights to the TOAs object
         for ii in range(len(weights)):
-            self.toas.table['flags'][ii]['weights'] = weights[ii]
+            self.toas.table['flags'][ii]['weights'] = str(weights[ii])
 
     # Check which telescope is in the file header
     def check_tele(self, data):
@@ -356,7 +356,7 @@ class MCMC:
         # phases = np.where(phss < 0.0 * u.cycle, phss + 1.0 * u.cycle, phss)
 
         # Pull out the first H-Test
-        htest = hmw(phases, np.array(self.toas.get_flag_value('weights')[0]))
+        htest = hmw(phases, np.array(self.toas.get_flag_value('weights')[0]).astype(float))
 
         print(htest)
 
@@ -379,7 +379,7 @@ class MCMC:
         # phases = np.where(phss < 0.0 * u.cycle, phss + 1.0 * u.cycle, phss)
 
         # Pull out the H-Test
-        htest = hmw(phases, np.array(self.toas.get_flag_value('weights')[0]))
+        htest = hmw(phases, np.array(self.toas.get_flag_value('weights')[0]).astype(float))
 
         #print(params)
         #print(htest)

--- a/EZPrefine_PINT_MCMC.py
+++ b/EZPrefine_PINT_MCMC.py
@@ -183,7 +183,9 @@ class MCMC:
             self.modelin = pint.models.get_model(self.args.par)
 
             # Read the saved pickle file
-            self.toas = toa.TOAs(self.args.load_pick + '.pickle')
+            self.toas = pint.toa.load_pickle(self.args.load_pick,
+                                             picklefilename=self.args.load_pick + '.pickle')
+            self.add_errors()
 
             # Create a toas_list from the loaded file
             #self.toas_list = toa.get_TOAs_list([self.toas.toas[:]])
@@ -199,9 +201,11 @@ class MCMC:
 
             # self.weights = np.load('weights_' + self.args.load_pick + '.npy')
 
+        # Saves the input data in the form of a pickle file for faster loading
+        # in the future.
         if self.args.save_pick is not False:
-            self.toas.pickle(filename=self.args.save_pick + '.pickle')
-            # np.save('weights_' + self.args.save_pick + '.npy' , self.weights)
+            pint.toa.save_pickle(self.toas,
+                                 picklefilename=self.args.save_pick + '.pickle')
 
         self.mid_save()
 
@@ -330,6 +334,7 @@ class MCMC:
         self.sampler = EmceeSampler(self.args.nwalkers)
 
         # Initialie PINT's MCMC object
+        print(self.toas)
         self.fitter = MCMCFitter(self.toas, self.modelin, self.sampler,
                                  lnlike=self.MCMC_htest)
         # self.fitter = MCMCFitter(self.toas, self.modelin, self.sampler,


### PR DESCRIPTION
Reflects PINT's change in the way saving and loading files is performed. Weights are now stored as strings, and converted to floats for use in the h-test (as opposed to being stored and used as floats). This likewise reflects a change in PINT. 